### PR TITLE
FIX: query execution: whatever function was chosen for a field, it was always getNomUrl() that was executed

### DIFF
--- a/class/query.class.php
+++ b/class/query.class.php
@@ -474,9 +474,7 @@ class TQuery extends TObjetStd {
 			foreach($this->TClass as $f=>$v) {
 				if($v) {
 					$fSearch = strtr($f,'.','_');
-
-					$method = empty($this->TMethod[$fSearch]) ? 'getNomUrl' : $this->TMethod[$fSearch];
-
+					$method = empty($this->TMethod[$f]) ? 'getNomUrl' : $this->TMethod[$f];
 					$Tab[$fSearch]= 'TQuery::getCustomMethodForObject("'.$v.'", "@val@", "'.$method.'")';
 				}
 


### PR DESCRIPTION
(Je suis un sac à merde qui retrouve du code non committé en préprod...)