### PR TITLE
New option to disable dashboard on cards plus fix menus

### DIFF
--- a/admin/query_setup.php
+++ b/admin/query_setup.php
@@ -61,7 +61,7 @@ if (preg_match('/set_(.*)/',$action,$reg))
 		dol_print_error($db);
 	}
 }
-	
+
 if (preg_match('/del_(.*)/',$action,$reg))
 {
 	$code=$reg[1];
@@ -231,6 +231,19 @@ if(! empty($conf->global->QUERY_HOME_SELECTOR))
 	print '</form>';
 	print '</td></tr>';
 }
+
+$var=!$var;
+print '<tr '.$bc[$var].'>';
+print '<td>'.$langs->trans("QUERY_NO_DASHBOARD_ON_CARDS").'</td>';
+print '<td align="center" width="20">&nbsp;</td>';
+print '<td align="right" width="300">';
+print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'">';
+print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
+print '<input type="hidden" name="action" value="set_QUERY_NO_DASHBOARD_ON_CARDS">';
+print $form->selectyesno("QUERY_NO_DASHBOARD_ON_CARDS",$conf->global->QUERY_NO_DASHBOARD_ON_CARDS,1);
+print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">';
+print '</form>';
+print '</td></tr>';
 
 print '</table>';
 

--- a/class/actions_query.class.php
+++ b/class/actions_query.class.php
@@ -9,13 +9,15 @@ class ActionsQuery
 	 */
 
 	function formObjectOptions($parameters, &$object, &$action, $hookmanager) {
-		global $user;
+		global $user, $conf;
 
 		if(($parameters['currentcontext'] == 'projectcard'
 		|| $parameters['currentcontext'] == 'productcard'
 		|| $parameters['currentcontext'] == 'thirdpartycard'
 		|| $parameters['currentcontext'] == 'usercard')
-		&& $action == '' && !empty($user->rights->query->dashboard->viewin)) {
+		&& $action == ''
+		&& empty($conf->global->QUERY_NO_DASHBOARD_ON_CARDS)
+		&& !empty($user->rights->query->dashboard->viewin)) {
 
 			define('INC_FROM_DOLIBARR',true);
 			dol_include_once('/query/config.php');

--- a/core/modules/modquery.class.php
+++ b/core/modules/modquery.class.php
@@ -81,7 +81,7 @@ class modquery extends DolibarrModules
         $this->module_parts = array(
            	'triggers'=>1
 			,'hooks'=>array('index','projectcard','productcard','thirdpartycard','usercard')
-            
+
         );
 
         // Data directories to create when module is enabled.
@@ -215,14 +215,14 @@ class modquery extends DolibarrModules
         // Permissions
         $this->rights = array(); // Permission array used by this module
 		$r=0;
-		
+
 		$this->rights[$r][0] = $this->numero+$r; 				// Permission id (must not be already used)
 		$this->rights[$r][1] = 'Exécuter une requête';	// Permission label
 		$this->rights[$r][3] = 0; 					// Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'all';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		$this->rights[$r][5] = 'read';				// In php code, permission will be_o checked by test if ($user->rights->permkey->level1->level2)
 		$r++;
-		
+
 		$this->rights[$r][0] = $this->numero+$r; 				// Permission id (must not be already used)
 		$this->rights[$r][1] = 'Créer une requête';	// Permission label
 		$this->rights[$r][3] = 0; 					// Permission by default for new user (0/1)
@@ -250,7 +250,7 @@ class modquery extends DolibarrModules
 		$this->rights[$r][4] = 'dashboard';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		$this->rights[$r][5] = 'viewin';			// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		$r++;
-		
+
 		$this->rights[$r][0] = $this->numero+$r; 				// Permission id (must not be already used)
 		$this->rights[$r][1] = 'Faire des requêtes en expert';	// Permission label
 		$this->rights[$r][3] = 0; 					// Permission by default for new user (0/1)
@@ -264,21 +264,21 @@ class modquery extends DolibarrModules
 		$this->rights[$r][4] = 'dashboard';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		$this->rights[$r][5] = 'read';			// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		$r++;
-		
+
 		$this->rights[$r][0] = $this->numero+$r; 				// Permission id (must not be already used)
 		$this->rights[$r][1] = 'ViewAllDashboard';	// Permission label
 		$this->rights[$r][3] = 0; 					// Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'dashboard';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		$this->rights[$r][5] = 'readall';			// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		$r++;
-		
+
 		$this->rights[$r][0] = $this->numero+$r; 				// Permission id (must not be already used)
 		$this->rights[$r][1] = 'UseOtherDB';	// Permission label
 		$this->rights[$r][3] = 0; 					// Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'bdd';				// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		$this->rights[$r][5] = 'use_other_db';			// In php code, permission will be checked by test if ($user->rights->permkey->level1->level2)
 		$r++;
-		
+
 
 
         // Add here list of permission defined by
@@ -314,9 +314,10 @@ class modquery extends DolibarrModules
         	'position'=>100,
         	'perms'=>'$user->rights->query->all->read',
         	'target'=>'',
-        	'user'=>2
+        	'user'=>2,
+			'enabled'=>1,
         );
-		
+
         $r++;
 
         $this->menu[$r]=array(
@@ -329,9 +330,10 @@ class modquery extends DolibarrModules
         	'position'=>102,
         	'perms'=>'$user->rights->query->all->create',
         	'target'=>'',
-        	'user'=>2
+        	'user'=>2,
+			'enabled'=>1,
         );
-		
+
         $r++;
 
 		$this->menu[$r]=array(
@@ -345,9 +347,10 @@ class modquery extends DolibarrModules
         	'position'=>101,
         	'perms'=>'$user->rights->query->all->read',
         	'target'=>'',
-        	'user'=>2
+        	'user'=>2,
+			'enabled'=>1,
         );
-		
+
 		$r++;
 
         $this->menu[$r]=array(
@@ -360,7 +363,8 @@ class modquery extends DolibarrModules
         	'position'=>201,
         	'perms'=>'$user->rights->query->dashboard->read',
         	'target'=>'',
-        	'user'=>2
+        	'user'=>2,
+			'enabled'=>1,
         );
 		$r++;
 
@@ -375,12 +379,13 @@ class modquery extends DolibarrModules
         	'position'=>202,
         	'perms'=>'$user->rights->query->dashboard->create',
         	'target'=>'',
-        	'user'=>2
+        	'user'=>2,
+			'enabled'=>1,
         );
-		
+
         $r++;
 
-        
+
         $this->menu[$r]=array(
         	'fk_menu'=>'fk_mainmenu=tools,fk_leftmenu=query',
         	'type'=>'left',
@@ -391,7 +396,8 @@ class modquery extends DolibarrModules
         	'perms'=>'$user->rights->query->all->create',
         	'position'=>311,
         	'target'=>'',
-        	'user'=>2
+        	'user'=>2,
+			'enabled'=>1,
         );
 		$r++;
 
@@ -406,12 +412,13 @@ class modquery extends DolibarrModules
         	'position'=>312,
         	'perms'=>'$user->rights->query->all->create',
         	'target'=>'',
-        	'user'=>2
+        	'user'=>2,
+			'enabled'=>1,
         );
-		
+
         $r++;
 
-        
+
         $this->menu[$r]=array(
         	'fk_menu'=>'fk_mainmenu=tools,fk_leftmenu=query',
         	'type'=>'left',
@@ -420,15 +427,15 @@ class modquery extends DolibarrModules
         	'leftmenu'=>'bdd_access',
         	'url'=>'/query/bdd.php',
         	'position'=>301,
-        	'enabled'=>'',
         	'langs'=>'query@query',
         	'perms'=>'$user->rights->query->bdd->write',
         	'target'=>'',
-        	'user'=>2
+        	'user'=>2,
+			'enabled'=>'',
         );
-		
+
         $r++;
-		
+
         $this->menu[$r]=array(
         	'fk_menu'=>'fk_mainmenu=tools,fk_leftmenu=query',
         	'type'=>'left',
@@ -437,16 +444,16 @@ class modquery extends DolibarrModules
         	'leftmenu'=>'bdd_access',
         	'url'=>'/query/bdd.php?action=new',
         	'position'=>302,
-        	'enabled'=>'',
         	'langs'=>'query@query',
         	'perms'=>'$user->rights->query->bdd->use_other_db',
         	'target'=>'',
-        	'user'=>2
+        	'user'=>2,
+			'enabled'=>'',
         );
-		
+
         $r++;
-		
-				
+
+
         //$this->menu[$r]=array(
         //	// Use r=value where r is index key used for the parent menu entry
         //	// (higher parent must be a top menu entry)
@@ -607,10 +614,10 @@ class modquery extends DolibarrModules
         $sql = array();
 
         $result = $this->loadTables();
-	
+
 	define('INC_FROM_DOLIBARR',true);
         dol_include_once('/query/script/create-maj-base.php');
-        
+
         return $this->_init($sql, $options);
     }
 

--- a/langs/en_US/query.lang
+++ b/langs/en_US/query.lang
@@ -56,3 +56,4 @@ query_warnings_set_expert_mode=Becareful, switch to expert mode can make your re
 query_warnings_set_expert_free_mode=Becareful, switch to free expert mode can make your request inoperative according to its complexity and / or during a return to assisted mode en mode assisté
 
 set_QUERY_DASHBOARD_OPEN_IN_NEW_TAB=Open hompage panels in a new tab instead of inside the widget
+QUERY_NO_DASHBOARD_ON_CARDS=Disable the query dashboard on project, product, third party and user cards

--- a/langs/fr_FR/query.lang
+++ b/langs/fr_FR/query.lang
@@ -94,3 +94,4 @@ query_warnings_set_expert_mode=Attention, le passage en mode expert peut rendre 
 query_warnings_set_expert_free_mode=Attention, le passage en mode expert libre peut rendre votre requête inopérante en fonction de sa complexité et/ou lors d'un retour en mode assisté
 
 set_QUERY_DASHBOARD_OPEN_IN_NEW_TAB=Développer les panneaux de la page d'accueil dans un nouvel onglet plutôt que dans le widget
+QUERY_NO_DASHBOARD_ON_CARDS=Désactiver le tableau de bord Query sur les fiches projet, produit, tiers et utilisateur


### PR DESCRIPTION
When a client's queries are outdated and no longer functional, the query dashboard popping on project, product, third party and user cards can be annoying. This PR offers a way to disable this dashboard on cards.

It also fixes a bug with Dolibarr v12.0 (and maybe also with older versions) which causes the menus not to appear when the module is enabled.